### PR TITLE
feat: autoinstall iptables

### DIFF
--- a/ansible/project/roles/iptables_get/tasks/main.yml
+++ b/ansible/project/roles/iptables_get/tasks/main.yml
@@ -9,7 +9,23 @@
         iptables: "{{ iptables.stdout }}"
         cacheable: yes
   rescue:
-    - name: Set iptables not exist
+    - name: Gather facts
+      gather_facts:
+        parallel: yes
+    - name: Install iptables for centos
+      when: ansible_facts.os_family == 'RedHat'
+      yum:
+        name: iptables
+        state: present
+    - name: Install iptables for debian/ubuntu
+      when: ansible_facts.os_family == 'Debian'
+      apt:
+        name: iptables
+        state: present
+    - name: Get iptables version
+      shell: iptables -V
+      register: iptables
+    - name: Set fact for iptables version
       set_fact:
-        iptables: ""
+        iptables: "{{ iptables.stdout }}"
         cacheable: yes


### PR DESCRIPTION
在 Debian10 OVZ 和 Debian11 KVM 下测试通过。不过可能逻辑还可以再优化，目前只有在连接ssh时候才会自动安装，如果连接以后删除系统的 iptables 再添加转发并不会自动安装，~~不过我相信没有用户这么干~~。