### PR TITLE
feat: autoinstall python

### DIFF
--- a/ansible/project/server.yml
+++ b/ansible/project/server.yml
@@ -1,8 +1,13 @@
 ---
 - hosts: "{{ host | default('web') }}"
   become: yes
-  gather_facts: yes
+  gather_facts: no
   pre_tasks:
+    - name: install python
+      raw: |
+        (python3 -V || python -V) || \
+        (yum makecache -y && (yum install -y python3 || yum install -y python)) || \
+        (apt update -y && (apt install -y python3 || apt install -y python))
     - name: get service facts
       service_facts:
       register: services


### PR DESCRIPTION
自动安装 python 支持，优先顺序 python3 > python2 ，已在 Debian 10 OVZ 和 Ubuntu 20 KVM 上测试通过。但可能会造成添加服务器后长时间转圈圈的问题，需要重新编辑一次服务器后才可以恢复正常。