### PR TITLE
feat: weaken systemd dependence

### DIFF
--- a/ansible/project/files/iptables.sh
+++ b/ansible/project/files/iptables.sh
@@ -17,6 +17,10 @@ check_system () {
         OS_FAMILY="debian"
         UPDATE="$SUDO apt update -y"
         INSTALL="$SUDO apt install -y --no-install-recommends"
+    elif [[ $ID == "alpine" ]]; then
+        OS_FAMILY="alpine"
+        UPDATE="$SUDO apk update"
+        INSTALL="$SUDO apk add --no-cache"
     fi
     # Not force to exit if the system is not supported
     systemctl --version > /dev/null 2>&1 && IS_SYSTEMD=1


### PR DESCRIPTION
减少 iptables 转发对 systemd 的依赖（如果系统不支持 systemd ，仅仅影响重启后 iptables 规则的自动恢复，不影响添加或修改删除 iptables 转发规则），并添加对更多系统依赖的检查和安装。已在 alpine 3.15 上测试通过，理论目前 iptables 应该支持大部分 linux 发行版本。