### PR TITLE
feat: silence service’s standard output

### DIFF
--- a/ansible/project/files/template.service
+++ b/ansible/project/files/template.service
@@ -14,6 +14,7 @@ LimitNOFILE=1048576
 LimitNPROC=51200
 RestartSec=2s
 Restart=on-failure
+StandardOutput=null
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
不保留 stdout 日志以减少被控机硬盘占用。