### PR TITLE
fix: iperf3 expire time

### DIFF
--- a/app/db/schemas/port_forward.py
+++ b/app/db/schemas/port_forward.py
@@ -156,10 +156,8 @@ class IperfConfig(BaseModel):
 
     @validator("expire_second", pre=True)
     def check_expire_second(cls, v):
-        if v <= 0:
-            raise ValueError("Expire second must be greater than 0")
-        elif v > 24 * 60 * 60:
-            raise ValueError(f"Expire second must be less than {24 * 60 * 60}")
+        if v <= 0 or v > 24 * 60 * 60:
+            v = 60 * 10  # default 10 min
         return v
 
     @validator("expire_time", pre=True, always=True)


### PR DESCRIPTION
`@validator("expire_time", pre=True, always=True)` 中 `always=True` 会导致 expire_second 抛出 `ValueError` 时仍能继续执行 `add_expire_time()` validator，最终会抛出 `KeyError: 'expire_seconds'` 异常，但该异常类型会使得前端网页上提示“服务器错误”的不友好错误信息。